### PR TITLE
Use Node 24 in CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -28,6 +28,11 @@ jobs:
 
     - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        node-version-file: package.json
+        cache: pnpm
+
     - name: Install dependencies
       run: pnpm install --frozen-lockfile
 
@@ -42,6 +47,11 @@ jobs:
         persist-credentials: false
 
     - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        node-version-file: package.json
+        cache: pnpm
 
     - name: Install dependencies
       run: pnpm install --frozen-lockfile
@@ -58,6 +68,11 @@ jobs:
 
     - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        node-version-file: package.json
+        cache: pnpm
+
     - name: Install dependencies
       run: pnpm install --frozen-lockfile
 
@@ -72,6 +87,11 @@ jobs:
         persist-credentials: false
 
     - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        node-version-file: package.json
+        cache: pnpm
 
     - name: Install dependencies
       run: pnpm install --frozen-lockfile
@@ -89,6 +109,11 @@ jobs:
           persist-credentials: false
       
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: package.json
+          cache: pnpm
       
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
 	"name": "githubstats",
 	"type": "module",
 	"packageManager": "pnpm@9.15.9",
+	"engines": {
+		"node": "24"
+	},
 	"scripts": {
 		"preinstall": "npx only-allow pnpm",
 		"dev": "wrangler dev",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+onlyBuiltDependencies:
+  - esbuild
+  - sharp
+  - workerd

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,0 @@
-onlyBuiltDependencies:
-  - esbuild
-  - sharp
-  - workerd


### PR DESCRIPTION
## Summary
- add package.json engines.node = 24
- make each CI job use actions/setup-node from package.json

## Context
pnpm v11 requires Node >=22.13, but the current workflow otherwise falls back to the runner default Node 20. This keeps the runtime source in package.json before Renovate pnpm v11 updates land.

## Validation
- git diff --check

Note: local pnpm script verification was blocked because pnpm tried to create a shim under ~/Library/pnpm, outside the writable sandbox.