### PR TITLE
[codex] Add Worker dry-run CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -98,3 +98,26 @@ jobs:
 
     - name: Run tests
       run: pnpm test
+
+  worker-dry-run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
+
+    - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        node-version-file: package.json
+        cache: pnpm
+
+    - name: Install dependencies
+      run: pnpm install --frozen-lockfile
+
+    - name: Compile Worker deployment
+      run: pnpm run deploy:dry-run
+
+    - name: Check Worker startup
+      run: pnpm run check:startup

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
 		"preinstall": "npx only-allow pnpm",
 		"dev": "wrangler dev",
 		"deploy": "wrangler deploy --minify",
+		"deploy:dry-run": "wrangler deploy --dry-run --minify --outdir dist/worker",
+		"check:startup": "wrangler check startup --args=\"--minify\"",
 		"cf-typegen": "wrangler types --env-interface CloudflareBindings",
 		"lint": "oxlint --deny-warnings .",
 		"lint:fix": "oxlint --deny-warnings . --fix",


### PR DESCRIPTION
## Summary
- add a Worker dry-run CI job that compiles the Cloudflare Worker without deploying it
- add a startup check so dependency/runtime issues can fail CI before Cloudflare App deployment

## Notes
- `deploy:dry-run` runs `wrangler deploy --dry-run --minify --outdir dist/worker`. It builds the deploy artifact locally but does not publish or switch production traffic.
- `check:startup` runs `wrangler check startup --args="--minify"` to exercise Worker startup/module evaluation more directly.
- This PR is intentionally draft so we can first see whether CI reproduces the current `satori@0.26.0` / `process is not defined` failure.

## Validation
- Not run locally by request; this PR is for CI-based reproduction.