### PR TITLE
[codex] Enable Node.js compatibility for Worker

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,6 +7,7 @@
 	"name": "githubstats",
 	"main": "src/index.ts",
 	"compatibility_date": "2025-07-15",
+	"compatibility_flags": ["nodejs_compat"],
 	"assets": {
 		"binding": "ASSETS",
 		"directory": "./public"


### PR DESCRIPTION
## Summary
- enable the Cloudflare Workers `nodejs_compat` compatibility flag
- make the Worker runtime provide Node.js globals such as `process`, which `satori@0.26.0` now references during module evaluation

## Why
Cloudflare Workers Builds currently fails while validating the uploaded Worker with:

```
Uncaught ReferenceError: process is not defined
  at .../satori/src/yoga.ts:23:5
```

`satori@0.26.0` uses `process.env.SATORI_STANDALONE` in its Yoga loader. The standard Workers runtime does not expose `process` unless Node.js compatibility is enabled.

## Validation
- Not run locally; this PR is intended to be validated by the Cloudflare Workers Builds check.