### PR TITLE
[codex] Use fixed timestamps for recent repos

### DIFF
--- a/src/features/recent-repos/components/RecentReposStats.test.tsx
+++ b/src/features/recent-repos/components/RecentReposStats.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll } from "vitest";
-import { RecentReposStats } from "./RecentReposStats";
+import { formatDate, RecentReposStats } from "./RecentReposStats";
 import { generateSVG } from "../../../shared/lib/svg-generator";
 import { getTestFontData } from "../../../test-utils/font-helper";
 
@@ -55,7 +55,12 @@ describe("RecentReposStats Component", () => {
 
     expect(svg).toContain("<svg");
     expect(svg).toContain("</svg>");
+    expect(svg).not.toContain("ago");
     expect(svg.length).toBeGreaterThan(5000);
+  });
+
+  it("should format pushedAt as an absolute UTC timestamp", () => {
+    expect(formatDate("2025-01-20T10:00:00Z")).toBe("2025-01-20 10:00");
   });
 
   it("should handle empty repository list", async () => {

--- a/src/features/recent-repos/components/RecentReposStats.tsx
+++ b/src/features/recent-repos/components/RecentReposStats.tsx
@@ -9,29 +9,15 @@ interface RecentReposStatsProps {
   repositories: RecentRepository[];
 }
 
-const formatDate = (dateString: string): string => {
+export const formatDate = (dateString: string): string => {
   const date = new Date(dateString);
-  const now = new Date();
-  const diffTime = Math.abs(now.getTime() - date.getTime());
-  const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  const hours = String(date.getUTCHours()).padStart(2, "0");
+  const minutes = String(date.getUTCMinutes()).padStart(2, "0");
 
-  if (diffDays === 0) {
-    const diffHours = Math.floor(diffTime / (1000 * 60 * 60));
-    if (diffHours === 0) {
-      const diffMinutes = Math.floor(diffTime / (1000 * 60));
-      return `${diffMinutes}m ago`;
-    }
-    return `${diffHours}h ago`;
-  }
-  if (diffDays < 7) {
-    return `${diffDays}d ago`;
-  }
-  if (diffDays < 30) {
-    const weeks = Math.floor(diffDays / 7);
-    return `${weeks}w ago`;
-  }
-  const months = Math.floor(diffDays / 30);
-  return `${months}mo ago`;
+  return `${year}-${month}-${day} ${hours}:${minutes}`;
 };
 
 export function RecentReposStats({ repositories }: RecentReposStatsProps) {
@@ -48,7 +34,7 @@ export function RecentReposStats({ repositories }: RecentReposStatsProps) {
     overflow: "hidden",
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
-    maxWidth: "200px",
+    maxWidth: "160px",
   };
 
   const languageContainerStyle: CSSProperties = {
@@ -65,7 +51,10 @@ export function RecentReposStats({ repositories }: RecentReposStatsProps) {
   const timeStyle: CSSProperties = {
     color: colors.text.secondary,
     fontSize: fonts.size.small,
+    fontVariantNumeric: "tabular-nums",
     flexShrink: 0,
+    width: "116px",
+    textAlign: "right",
   };
 
   return (


### PR DESCRIPTION
## Summary

- Replace relative `ago` labels in the recent repositories SVG with fixed UTC timestamps.
- Right-align the timestamp column and use tabular numbers so cached SVG output stays visually stable.
- Add coverage for the timestamp formatter and ensure the rendered SVG no longer includes relative time text.

## Why

The previous relative time labels were calculated when the SVG was generated, then cached in KV. That made labels like `3h ago` stale while the cached image stayed in use.

## Validation

- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/oxfmt --check src/`
- `./node_modules/.bin/oxlint --deny-warnings .`
- `./node_modules/.bin/vitest run src/features/recent-repos/components/RecentReposStats.test.tsx`