### PR TITLE
[codex] Add weekly activity stats card

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ GitHub language statistics SVG generator built with Cloudflare Workers.
 
 ## Features
 
-- 📊 Three statistics views: language usage, recent repos, recent languages
+- 📊 Four statistics views: language usage, recent repos, recent languages, weekly activity
 - ⚡ xfetch caching algorithm prevents stampeding
 - 🎨 SVG generation with React + Satori
 - 🚀 Edge deployment on Cloudflare Workers
@@ -28,8 +28,9 @@ pnpm run deploy
 ## Endpoints
 
 - `/stats/language` - Overall language statistics
-- `/stats/recent-repos` - Recently updated repositories  
+- `/stats/recent-repos` - Recently updated repositories
 - `/stats/recent-languages` - Recent language usage
+- `/stats/weekly-activity` - Weekly repository activity
 
 ## Usage
 
@@ -37,6 +38,7 @@ pnpm run deploy
 ![Language Stats](https://your-worker.workers.dev/stats/language)
 ![Recent Repos](https://your-worker.workers.dev/stats/recent-repos)
 ![Recent Languages](https://your-worker.workers.dev/stats/recent-languages)
+![Weekly Activity](https://your-worker.workers.dev/stats/weekly-activity)
 ```
 
 ## Development
@@ -58,7 +60,7 @@ pnpm wrangler kv key list --local --namespace-id <preview-namespace-id> | jq -r 
 ## Configuration
 
 - **GitHub Username**: Set in `wrangler.jsonc`
-- **GitHub Token**: 
+- **GitHub Token**:
   - Dev: `.dev.vars` file
   - Prod: `wrangler secret put GITHUB_TOKEN`
 

--- a/src/features/weekly-activity/api.test.ts
+++ b/src/features/weekly-activity/api.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { buildWeeklyRepositoryActivities, getWeeklyActivityRange } from "./api";
+import type { WeeklyActivityRepositoryNode } from "../../services/github/types";
+
+function repo(
+  name: string,
+  committedDates: string[],
+  isFork = false,
+): WeeklyActivityRepositoryNode {
+  return {
+    name,
+    isFork,
+    defaultBranchRef: {
+      target: {
+        targetType: "Commit",
+        history: {
+          totalCount: committedDates.length,
+          nodes: committedDates.map((committedDate) => ({ committedDate })),
+        },
+      },
+    },
+  };
+}
+
+describe("weekly activity api", () => {
+  it("builds a seven-day UTC range including today", () => {
+    const range = getWeeklyActivityRange(new Date("2026-06-17T15:30:00Z"));
+
+    expect(range).toEqual({
+      since: "2026-06-11T00:00:00.000Z",
+      until: "2026-06-18T00:00:00.000Z",
+    });
+  });
+
+  it("builds daily counts and sorts repositories by weekly activity", () => {
+    const activities = buildWeeklyRepositoryActivities(
+      [
+        repo("small-repo", ["2026-06-15T09:00:00Z"]),
+        repo("busy-repo", ["2026-06-12T09:00:00Z", "2026-06-12T10:00:00Z", "2026-06-17T11:00:00Z"]),
+      ],
+      "2026-06-11T00:00:00.000Z",
+    );
+
+    expect(activities).toEqual([
+      {
+        name: "busy-repo",
+        dailyCounts: [0, 2, 0, 0, 0, 0, 1],
+      },
+      {
+        name: "small-repo",
+        dailyCounts: [0, 0, 0, 0, 1, 0, 0],
+      },
+    ]);
+  });
+
+  it("filters forks, repos with no commits, and applies the display limit", () => {
+    const activities = buildWeeklyRepositoryActivities(
+      [
+        repo("one", ["2026-06-11T09:00:00Z"]),
+        repo("two", ["2026-06-12T09:00:00Z"]),
+        repo("forked", ["2026-06-13T09:00:00Z"], true),
+        repo("empty", []),
+      ],
+      "2026-06-11T00:00:00.000Z",
+      1,
+    );
+
+    expect(activities).toEqual([
+      {
+        name: "one",
+        dailyCounts: [1, 0, 0, 0, 0, 0, 0],
+      },
+    ]);
+  });
+});

--- a/src/features/weekly-activity/api.ts
+++ b/src/features/weekly-activity/api.ts
@@ -1,0 +1,94 @@
+import type {
+  WeeklyActivityQueryData,
+  WeeklyActivityRepositoryNode,
+  WeeklyRepositoryActivity,
+} from "../../services/github/types";
+import { executeGraphQLQuery } from "../../services/github/client";
+import { WEEKLY_ACTIVITY_QUERY } from "../../services/github/queries";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const DAYS_IN_WEEK = 7;
+
+export function getWeeklyActivityRange(now = new Date()): { since: string; until: string } {
+  const todayUtc = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  const since = new Date(todayUtc - (DAYS_IN_WEEK - 1) * DAY_MS);
+  const until = new Date(todayUtc + DAY_MS);
+
+  return {
+    since: since.toISOString(),
+    until: until.toISOString(),
+  };
+}
+
+export function buildWeeklyRepositoryActivities(
+  repositories: WeeklyActivityRepositoryNode[],
+  since: string,
+  limit = 5,
+): WeeklyRepositoryActivity[] {
+  const dayKeys = Array.from({ length: DAYS_IN_WEEK }, (_, index) => {
+    const date = new Date(new Date(since).getTime() + index * DAY_MS);
+    return date.toISOString().slice(0, 10);
+  });
+
+  return repositories
+    .filter((repo) => !repo.isFork)
+    .map((repo) => {
+      const countsByDay = new Map(dayKeys.map((dayKey) => [dayKey, 0]));
+      const history = repo.defaultBranchRef?.target.history;
+
+      if (repo.defaultBranchRef?.target.targetType === "Commit" && history) {
+        for (const commit of history.nodes) {
+          const dayKey = commit.committedDate.slice(0, 10);
+          const count = countsByDay.get(dayKey);
+
+          if (count !== undefined) {
+            countsByDay.set(dayKey, count + 1);
+          }
+        }
+      }
+
+      return {
+        name: repo.name,
+        dailyCounts: dayKeys.map((dayKey) => countsByDay.get(dayKey) ?? 0),
+      };
+    })
+    .filter((repo) => repo.dailyCounts.some((count) => count > 0))
+    .toSorted((a, b) => {
+      const totalA = a.dailyCounts.reduce((sum, count) => sum + count, 0);
+      const totalB = b.dailyCounts.reduce((sum, count) => sum + count, 0);
+
+      return totalB - totalA || a.name.localeCompare(b.name);
+    })
+    .slice(0, limit);
+}
+
+export async function fetchWeeklyActivity(
+  username: string,
+  githubToken?: string,
+  repoLimit = 30,
+): Promise<WeeklyRepositoryActivity[]> {
+  if (!githubToken) {
+    throw new Error("GitHub token is required for API access");
+  }
+
+  try {
+    const { since, until } = getWeeklyActivityRange();
+    const data = await executeGraphQLQuery<WeeklyActivityQueryData>(
+      WEEKLY_ACTIVITY_QUERY,
+      { username, repoLimit, since, until },
+      githubToken,
+    );
+
+    if (!data.user?.repositories) {
+      throw new Error("User not found or no repositories");
+    }
+
+    return buildWeeklyRepositoryActivities(
+      data.user.repositories.edges.map((edge) => edge.node),
+      since,
+    );
+  } catch (error) {
+    console.error("Error fetching weekly activity:", error);
+    throw error;
+  }
+}

--- a/src/features/weekly-activity/components/WeeklyActivityStats.test.tsx
+++ b/src/features/weekly-activity/components/WeeklyActivityStats.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { generateSVG } from "../../../shared/lib/svg-generator";
+import { getTestFontData } from "../../../test-utils/font-helper";
+import { WeeklyActivityStats } from "./WeeklyActivityStats";
+
+describe("WeeklyActivityStats Component", () => {
+  let fontData: ArrayBuffer;
+
+  beforeAll(async () => {
+    fontData = await getTestFontData();
+  });
+
+  const renderToSVG = (component: Parameters<typeof generateSVG>[0]) =>
+    generateSVG(component, {
+      width: 400,
+      height: 200,
+      fonts: [{ name: "Inter", data: fontData, weight: 400, style: "normal" }],
+    });
+
+  it("should render weekly activity cells", async () => {
+    const svg = await renderToSVG(
+      <WeeklyActivityStats
+        repositories={[
+          { name: "githubstats", dailyCounts: [0, 1, 2, 7, 0, 1, 6] },
+          { name: "hello-tree-sitter", dailyCounts: [0, 2, 0, 0, 7, 0, 0] },
+        ]}
+      />,
+    );
+
+    expect(svg).toContain("<svg");
+    expect(svg).toContain("</svg>");
+    expect(svg).toContain("#39d353");
+    expect(svg).toContain("#0e4429");
+    expect(svg.length).toBeGreaterThan(3000);
+  });
+
+  it("should handle empty repository list", async () => {
+    const svg = await renderToSVG(<WeeklyActivityStats repositories={[]} />);
+
+    expect(svg).toContain("<svg");
+    expect(svg).toContain("</svg>");
+    expect(svg.length).toBeGreaterThan(1000);
+  });
+});

--- a/src/features/weekly-activity/components/WeeklyActivityStats.tsx
+++ b/src/features/weekly-activity/components/WeeklyActivityStats.tsx
@@ -1,0 +1,80 @@
+import type { CSSProperties } from "hono/jsx";
+import type { WeeklyRepositoryActivity } from "../../../services/github/types";
+import { Card } from "../../../shared/components/Card/Card";
+import { colors } from "../../../shared/lib/colors";
+import { fonts } from "../../../shared/lib/fonts";
+
+interface WeeklyActivityStatsProps {
+  repositories: WeeklyRepositoryActivity[];
+}
+
+const DAY_KEYS = ["day-1", "day-2", "day-3", "day-4", "day-5", "day-6", "day-7"];
+
+function getActivityColor(count: number): string {
+  if (count >= 7) {
+    return "#39d353";
+  }
+
+  if (count >= 2) {
+    return "#26a641";
+  }
+
+  if (count >= 1) {
+    return "#0e4429";
+  }
+
+  return colors.background.secondary;
+}
+
+export function WeeklyActivityStats({ repositories }: WeeklyActivityStatsProps) {
+  const repoItemStyle: CSSProperties = {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    fontSize: fonts.size.body,
+    gap: "16px",
+  };
+
+  const repoNameStyle: CSSProperties = {
+    fontWeight: fonts.weight.medium,
+    color: colors.text.primary,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+    maxWidth: "190px",
+  };
+
+  const cellsStyle: CSSProperties = {
+    display: "flex",
+    gap: "5px",
+    flexShrink: 0,
+  };
+
+  const cellStyle = (count: number): CSSProperties => ({
+    width: "12px",
+    height: "12px",
+    borderRadius: "3px",
+    backgroundColor: getActivityColor(count),
+    border: count === 0 ? "1px solid rgba(255, 255, 255, 0.10)" : "1px solid transparent",
+    boxSizing: "border-box",
+  });
+
+  return (
+    <Card title="Weekly Activity">
+      <div style={{ display: "flex", flexDirection: "column", gap: "10px" }}>
+        {repositories.map((repo) => (
+          <div key={repo.name} style={repoItemStyle}>
+            <span style={repoNameStyle}>{repo.name}</span>
+            <div style={cellsStyle}>
+              {repo.dailyCounts.map((count, index) => {
+                const dayKey = DAY_KEYS[index] ?? `day-${repo.dailyCounts.length}`;
+
+                return <div key={`${repo.name}-${dayKey}`} style={cellStyle(count)} />;
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+}

--- a/src/features/weekly-activity/generator.test.ts
+++ b/src/features/weekly-activity/generator.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { generateWeeklyActivitySVG } from "./generator";
+import type { WeeklyRepositoryActivity } from "../../services/github/types";
+
+vi.mock("./api", () => ({
+  fetchWeeklyActivity: vi.fn(),
+}));
+
+import { fetchWeeklyActivity } from "./api";
+
+describe("generateWeeklyActivitySVG Integration", () => {
+  const testUsername = "testuser";
+  const testToken = "test-token";
+
+  const mockActivity: WeeklyRepositoryActivity[] = [
+    { name: "githubstats", dailyCounts: [0, 1, 2, 4, 0, 1, 4] },
+    { name: "hello-tree-sitter", dailyCounts: [0, 2, 0, 0, 4, 0, 0] },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fetchWeeklyActivity).mockResolvedValue(mockActivity);
+  });
+
+  it("should generate valid SVG with weekly activity", async () => {
+    const svg = await generateWeeklyActivitySVG({
+      username: testUsername,
+      githubToken: testToken,
+    });
+
+    expect(svg).toContain("<svg");
+    expect(svg).toContain('width="400"');
+    expect(svg).toContain('height="200"');
+    expect(svg).toContain('viewBox="0 0 400 200"');
+    expect(svg).toContain("</svg>");
+    expect(fetchWeeklyActivity).toHaveBeenCalledWith(testUsername, testToken);
+  });
+
+  it("should handle API errors gracefully", async () => {
+    const error = new Error("GitHub API Error");
+    vi.mocked(fetchWeeklyActivity).mockRejectedValue(error);
+
+    await expect(
+      generateWeeklyActivitySVG({
+        username: testUsername,
+        githubToken: testToken,
+      }),
+    ).rejects.toThrow("GitHub API Error");
+  });
+});

--- a/src/features/weekly-activity/generator.tsx
+++ b/src/features/weekly-activity/generator.tsx
@@ -1,0 +1,23 @@
+import type { BaseSVGOptions } from "../../types/svg-options";
+import { loadInterFonts } from "../../shared/lib/font-loader";
+import { generateSVG } from "../../shared/lib/svg-generator";
+import { fetchWeeklyActivity } from "./api";
+import { WeeklyActivityStats } from "./components/WeeklyActivityStats";
+
+export async function generateWeeklyActivitySVG({
+  username,
+  githubToken,
+}: BaseSVGOptions): Promise<string> {
+  const [fonts, repositories] = await Promise.all([
+    loadInterFonts(),
+    fetchWeeklyActivity(username, githubToken),
+  ]);
+
+  const svg = await generateSVG(<WeeklyActivityStats repositories={repositories} />, {
+    width: 400,
+    height: 200,
+    fonts,
+  });
+
+  return svg;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { generateLanguageStatsSVG } from "./features/language-stats/generator";
 import { generateRecentReposSVG } from "./features/recent-repos/generator";
 import { generateRecentLanguagesSVG } from "./features/recent-languages/generator";
+import { generateWeeklyActivitySVG } from "./features/weekly-activity/generator";
 import { handleCachedRequest } from "./services/cache/handler";
 import type { BaseSVGOptions } from "./types/svg-options";
 
@@ -33,5 +34,6 @@ createSVGEndpoint(
   generateRecentLanguagesSVG,
   "recent languages SVG",
 );
+createSVGEndpoint(app, "/stats/weekly-activity", generateWeeklyActivitySVG, "weekly activity SVG");
 
 export default app;

--- a/src/services/github/queries.ts
+++ b/src/services/github/queries.ts
@@ -70,3 +70,31 @@ export const RECENT_REPOSITORIES_QUERY = `
     }
   }
 `;
+
+export const WEEKLY_ACTIVITY_QUERY = `
+  query($username: String!, $repoLimit: Int!, $since: GitTimestamp!, $until: GitTimestamp!) {
+    user(login: $username) {
+      repositories(first: $repoLimit, ownerAffiliations: OWNER, orderBy: {field: PUSHED_AT, direction: DESC}) {
+        edges {
+          node {
+            name
+            isFork
+            defaultBranchRef {
+              target {
+                targetType: __typename
+                ... on Commit {
+                  history(first: 100, since: $since, until: $until) {
+                    totalCount
+                    nodes {
+                      committedDate
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;

--- a/src/services/github/types.ts
+++ b/src/services/github/types.ts
@@ -59,3 +59,32 @@ export interface RecentRepositoriesQueryData {
     };
   };
 }
+
+export interface WeeklyActivityRepositoryNode {
+  name: string;
+  isFork: boolean;
+  defaultBranchRef: {
+    target: {
+      targetType: string;
+      history?: {
+        totalCount: number;
+        nodes: Array<{
+          committedDate: string;
+        }>;
+      };
+    };
+  } | null;
+}
+
+export interface WeeklyActivityQueryData {
+  user: {
+    repositories: {
+      edges: Array<{ node: WeeklyActivityRepositoryNode }>;
+    };
+  };
+}
+
+export interface WeeklyRepositoryActivity {
+  name: string;
+  dailyCounts: number[];
+}


### PR DESCRIPTION
## Summary
- Add a new `/stats/weekly-activity` SVG endpoint.
- Aggregate default-branch commits from the last 7 UTC days and rank active repositories by weekly commit volume.
- Render a compact 7-cell activity strip per repository with 4 visual levels: 0, 1, 2-6, and 7+ commits.
- Document the new endpoint in the README.

## Validation
- `pnpm run fmt:check`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test`
- Rendered the local SVG through Wrangler and checked the PNG preview.